### PR TITLE
Make compatible with google-syncinator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
-- 1.9.3
 - 2.0.0
-- 2.1.0
 - 2.1.4
 services:
 - mongodb

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in google_syncinator_api_client.gemspec
 gemspec

--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 by Biola University
+Copyright (c) 2015 by Biola University
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 GoogleSyncinator API Client [![Build Status](https://travis-ci.org/biola/google-syncinator-api-client.svg?branch=master)](https://travis-ci.org/biola/google-syncinator-api-client)
 ==================
 
+Google Syncinator API Client is a client to the [google-syncinator](https://github.com/biola/google-syncinator) API (duh!)
+
 Installing
 ----------
 
@@ -23,6 +25,11 @@ GoogleSyncinatorAPIClient.configure do |config|
 end
 ```
 
+Getting Credentials
+-------------------
+
+To create a google-syncinator client and get an `access_id` and `secret_key`, see the [google-syncinator README](https://github.com/biola/google-syncinator/blob/master/README.md).
+
 Usage
 -----
 
@@ -32,10 +39,28 @@ Usage
 require 'google_syncinator_api_client'
 require 'multi_json'
 
-google_syncinator = GoogleSyncinator::APIClient::Emails.new
+emails_api = GoogleSyncinator::APIClient::Emails.new
+emails = emails_api.index.perform.parse
+emails_api.show(id: emails.first['id']).perform.parse
+
+person_emails_api = GoogleSyncinator::APIClient::PersonEmails.new
+person_email = person_emails_api.create(uuid: 'TROGDIR_PERSON_UUID', address: 'test@example.com').perform.parse
+person_emails_api.show(id: person_email['id']).perform
+
+alias_emails_api = GoogleSyncinator::APIClient::AliasEmails.new
+alias_email = alias_emails_api.create(account_email_id: person_email['id'], address: 'test@example.com').perform.parse
+alias_emails_api.show(id: alias_email['id']).perform
+
+deprovision_schedules_api = GoogleSyncinator::APIClient::DeprovisionSchedules.new
+deprovision_schedule = deprovision_schedules_api.create(email_id: person_email['id'], action: :suspend, scheduled_for: Time.now).perform.parse
+deprovision_schedules_api.update(email_id: person_email['id'], id: deprovision_schedule['id'], canceled: true).perform
+deprovision_schedules_api.destroy(email_id: person_email['id'], id: deprovision_schedule['id']).perform
+
+exclusions_api = GoogleSyncinator::APIClient::Exclusions.new
+exclusion_api = exclusions_api.create(email_id: person_email['id'], creator_uuid: 'TROGDIR_PERSON_UUID', starts_at: Time.now).perform.parse
+exclusions_api.destroy(email_id: person_email['id'], id: exclusion_api['id']).perform
 ```
 
 License
 -------
-
-MIT
+[MIT](https://github.com/biola/google-syncinator-api-client/blob/master/MIT-LICENSE)

--- a/google_syncinator_api_client.gemspec
+++ b/google_syncinator_api_client.gemspec
@@ -6,8 +6,8 @@ require 'google_syncinator_api_client/version'
 spec = Gem::Specification.new do |s|
   s.name = 'google_syncinator_api_client'
   s.version = GoogleSyncinatorAPIClient::VERSION
-  s.summary = 'Client for the GoogleSyncinator directory API'
-  s.description = 'API consuming models for the GoogleSyncinator directory project'
+  s.summary = 'Client for the GoogleSyncinator API'
+  s.description = 'API consuming models for the GoogleSyncinator project'
   s.files = Dir['README.*', 'MIT-LICENSE', 'lib/**/*.rb']
   s.require_path = 'lib'
   s.author = 'Michael Stephens'
@@ -20,7 +20,7 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency 'webmock', '~> 1.17'
   s.add_development_dependency 'factory_girl', '~> 4.4'
   s.add_development_dependency 'faker', '~> 1.3'
-  s.add_development_dependency 'google_syncinator_api'
+  # s.add_development_dependency 'google_syncinator'
   s.add_development_dependency 'pry', '~> 0.9'
   s.add_development_dependency 'pry-stack_explorer', '~> 0.4'
 end

--- a/lib/google_syncinator/api_client/account_emails.rb
+++ b/lib/google_syncinator/api_client/account_emails.rb
@@ -1,0 +1,13 @@
+module GoogleSyncinator
+  module APIClient
+    class AccountEmails < Weary::Client
+      include Settings
+
+      get :search, '/account_emails' do |resource|
+        resource.required :q
+      end
+
+      get :show, '/account_emails/{id}'
+    end
+  end
+end

--- a/lib/google_syncinator/api_client/alias_emails.rb
+++ b/lib/google_syncinator/api_client/alias_emails.rb
@@ -1,0 +1,13 @@
+module GoogleSyncinator
+  module APIClient
+    class AliasEmails < Weary::Client
+      include Settings
+
+      get :show, '/alias_emails/{id}'
+
+      post :create, '/alias_emails' do |resource|
+        resource.required :account_email_id, :address
+      end
+    end
+  end
+end

--- a/lib/google_syncinator/api_client/department_emails.rb
+++ b/lib/google_syncinator/api_client/department_emails.rb
@@ -9,6 +9,10 @@ module GoogleSyncinator
         resource.required :address, :uuids, :first_name, :last_name
         resource.optional :department, :title, :privacy
       end
+
+      put :update, '/department_emails/{id}' do |resource|
+        resource.optional :address, :uuids, :first_name, :last_name, :department, :title, :privacy
+      end
     end
   end
 end

--- a/lib/google_syncinator/api_client/department_emails.rb
+++ b/lib/google_syncinator/api_client/department_emails.rb
@@ -7,11 +7,11 @@ module GoogleSyncinator
 
       post :create, '/department_emails' do |resource|
         resource.required :address, :uuids, :first_name, :last_name
-        resource.optional :department, :title, :privacy
+        resource.optional :password, :department, :title, :privacy
       end
 
       put :update, '/department_emails/{id}' do |resource|
-        resource.optional :address, :uuids, :first_name, :last_name, :department, :title, :privacy
+        resource.optional :address, :uuids, :password, :first_name, :last_name, :department, :title, :privacy
       end
     end
   end

--- a/lib/google_syncinator/api_client/department_emails.rb
+++ b/lib/google_syncinator/api_client/department_emails.rb
@@ -1,0 +1,14 @@
+module GoogleSyncinator
+  module APIClient
+    class DepartmentEmails < Weary::Client
+      include Settings
+
+      get :show, '/department_emails/{id}'
+
+      post :create, '/department_emails' do |resource|
+        resource.required :address, :uuids, :first_name, :last_name
+        resource.optional :department, :title, :privacy
+      end
+    end
+  end
+end

--- a/lib/google_syncinator/api_client/deprovision_schedules.rb
+++ b/lib/google_syncinator/api_client/deprovision_schedules.rb
@@ -1,0 +1,20 @@
+module GoogleSyncinator
+  module APIClient
+    class DeprovisionSchedules < Weary::Client
+      include Settings
+
+      post :create, '/emails/{email_id}/deprovision_schedules' do |resource|
+        resource.required :action, :scheduled_for
+        resource.optional :reason
+      end
+
+      put :update, '/emails/{email_id}/deprovision_schedules/{id}' do |resource|
+        # There shouldn't be any reason to update a deprovision schedule other
+        #   than to cancel it
+        resource.required :canceled
+      end
+
+      delete :destroy, '/emails/{email_id}/deprovision_schedules/{id}'
+    end
+  end
+end

--- a/lib/google_syncinator/api_client/emails.rb
+++ b/lib/google_syncinator/api_client/emails.rb
@@ -3,8 +3,19 @@ module GoogleSyncinator
     class Emails < Weary::Client
       include Settings
 
-      put :update, '/people/{uuid}/emails/{email_id}' do |resource|
-        resource.required :old_address, :new_address
+      get :index, '/emails' do |resource|
+        resource.optional :q, :page, :per_page, :offset
+      end
+
+      get :show, '/emails/{id}'
+
+      put :create, '/emails' do |resource|
+        resource.required :uuid, :address
+        resource.optional :primary
+      end
+
+      put :update, '/emails/{id}' do |resource|
+        resource.required :primary
       end
     end
   end

--- a/lib/google_syncinator/api_client/emails.rb
+++ b/lib/google_syncinator/api_client/emails.rb
@@ -8,15 +8,6 @@ module GoogleSyncinator
       end
 
       get :show, '/emails/{id}'
-
-      post :create, '/emails' do |resource|
-        resource.required :uuid, :address
-        resource.optional :primary
-      end
-
-      put :update, '/emails/{id}' do |resource|
-        resource.required :primary
-      end
     end
   end
 end

--- a/lib/google_syncinator/api_client/emails.rb
+++ b/lib/google_syncinator/api_client/emails.rb
@@ -4,7 +4,7 @@ module GoogleSyncinator
       include Settings
 
       get :index, '/emails' do |resource|
-        resource.optional :q, :page, :per_page, :offset
+        resource.optional :q, :state, :pending, :page, :per_page, :offset
       end
 
       get :show, '/emails/{id}'

--- a/lib/google_syncinator/api_client/emails.rb
+++ b/lib/google_syncinator/api_client/emails.rb
@@ -9,7 +9,7 @@ module GoogleSyncinator
 
       get :show, '/emails/{id}'
 
-      put :create, '/emails' do |resource|
+      post :create, '/emails' do |resource|
         resource.required :uuid, :address
         resource.optional :primary
       end

--- a/lib/google_syncinator/api_client/exclusions.rb
+++ b/lib/google_syncinator/api_client/exclusions.rb
@@ -1,0 +1,14 @@
+module GoogleSyncinator
+  module APIClient
+    class Exclusions < Weary::Client
+      include Settings
+
+      post :create, '/emails/{email_id}/exclusions' do |resource|
+        resource.required :creator_uuid, :starts_at
+        resource.optional :ends_at, :reason
+      end
+
+      delete :destroy, '/emails/{email_id}/exclusions/{id}'
+    end
+  end
+end

--- a/lib/google_syncinator/api_client/person_emails.rb
+++ b/lib/google_syncinator/api_client/person_emails.rb
@@ -8,6 +8,10 @@ module GoogleSyncinator
       post :create, '/person_emails' do |resource|
         resource.required :uuid, :address
       end
+
+      put :update, '/person_emails/{id}' do |resource|
+        resource.required :address
+      end
     end
   end
 end

--- a/lib/google_syncinator/api_client/person_emails.rb
+++ b/lib/google_syncinator/api_client/person_emails.rb
@@ -7,7 +7,6 @@ module GoogleSyncinator
 
       post :create, '/person_emails' do |resource|
         resource.required :uuid, :address
-        resource.optional :primary
       end
     end
   end

--- a/lib/google_syncinator/api_client/person_emails.rb
+++ b/lib/google_syncinator/api_client/person_emails.rb
@@ -1,0 +1,14 @@
+module GoogleSyncinator
+  module APIClient
+    class PersonEmails < Weary::Client
+      include Settings
+
+      get :show, '/person_emails/{id}'
+
+      post :create, '/person_emails' do |resource|
+        resource.required :uuid, :address
+        resource.optional :primary
+      end
+    end
+  end
+end

--- a/lib/google_syncinator/api_client/settings.rb
+++ b/lib/google_syncinator/api_client/settings.rb
@@ -1,0 +1,11 @@
+module GoogleSyncinator
+  module APIClient
+    module Settings
+      def self.included(base)
+        base.send :domain, GoogleSyncinatorAPIClient.config.base_url
+        base.send :adapter, Weary::Adapter::NetHttpAdvanced
+        base.send :use, Weary::Middleware::HMACAuth, [GoogleSyncinatorAPIClient.config.credentials]
+      end
+    end
+  end
+end

--- a/lib/google_syncinator_api_client.rb
+++ b/lib/google_syncinator_api_client.rb
@@ -15,14 +15,7 @@ end
 module GoogleSyncinator
   module APIClient
     autoload :Settings, 'google_syncinator/api_client/settings'
-    autoload :People, 'google_syncinator/api_client/people'
-    autoload :IDs, 'google_syncinator/api_client/ids'
     autoload :Emails, 'google_syncinator/api_client/emails'
-    autoload :Phones, 'google_syncinator/api_client/phones'
-    autoload :Photos, 'google_syncinator/api_client/photos'
-    autoload :Addresses, 'google_syncinator/api_client/addresses'
-    autoload :ChangeSyncs, 'google_syncinator/api_client/change_syncs'
-    autoload :Groups, 'google_syncinator/api_client/groups'
   end
 end
 

--- a/lib/google_syncinator_api_client.rb
+++ b/lib/google_syncinator_api_client.rb
@@ -16,6 +16,7 @@ module GoogleSyncinator
   module APIClient
     autoload :Settings, 'google_syncinator/api_client/settings'
     autoload :DeprovisionSchedules, 'google_syncinator/api_client/deprovision_schedules'
+    autoload :AccountEmails, 'google_syncinator/api_client/account_emails'
     autoload :AliasEmails, 'google_syncinator/api_client/alias_emails'
     autoload :Emails, 'google_syncinator/api_client/emails'
     autoload :PersonEmails, 'google_syncinator/api_client/person_emails'

--- a/lib/google_syncinator_api_client.rb
+++ b/lib/google_syncinator_api_client.rb
@@ -19,6 +19,7 @@ module GoogleSyncinator
     autoload :AliasEmails, 'google_syncinator/api_client/alias_emails'
     autoload :Emails, 'google_syncinator/api_client/emails'
     autoload :PersonEmails, 'google_syncinator/api_client/person_emails'
+    autoload :DepartmentEmails, 'google_syncinator/api_client/department_emails'
     autoload :Exclusions, 'google_syncinator/api_client/exclusions'
   end
 end

--- a/lib/google_syncinator_api_client.rb
+++ b/lib/google_syncinator_api_client.rb
@@ -16,7 +16,9 @@ module GoogleSyncinator
   module APIClient
     autoload :Settings, 'google_syncinator/api_client/settings'
     autoload :DeprovisionSchedules, 'google_syncinator/api_client/deprovision_schedules'
+    autoload :AliasEmails, 'google_syncinator/api_client/alias_emails'
     autoload :Emails, 'google_syncinator/api_client/emails'
+    autoload :PersonEmails, 'google_syncinator/api_client/person_emails'
     autoload :Exclusions, 'google_syncinator/api_client/exclusions'
   end
 end

--- a/lib/google_syncinator_api_client.rb
+++ b/lib/google_syncinator_api_client.rb
@@ -16,6 +16,7 @@ module GoogleSyncinator
   module APIClient
     autoload :Settings, 'google_syncinator/api_client/settings'
     autoload :Emails, 'google_syncinator/api_client/emails'
+    autoload :Exclusions, 'google_syncinator/api_client/exclusions'
   end
 end
 

--- a/lib/google_syncinator_api_client.rb
+++ b/lib/google_syncinator_api_client.rb
@@ -15,6 +15,7 @@ end
 module GoogleSyncinator
   module APIClient
     autoload :Settings, 'google_syncinator/api_client/settings'
+    autoload :DeprovisionSchedules, 'google_syncinator/api_client/deprovision_schedules'
     autoload :Emails, 'google_syncinator/api_client/emails'
     autoload :Exclusions, 'google_syncinator/api_client/exclusions'
   end


### PR DESCRIPTION
This commit will provide compatibility with the [latest version of google-syncinator](https://github.com/biola/google-syncinator/pull/17).

Up until now this project was mostly a placeholder, there was no google-syncinator API to consume and the code was not production ready. This pull request should make this project ready for a gem release.